### PR TITLE
change admin logout url

### DIFF
--- a/JeJu/src/main/webapp/WEB-INF/spring/security-context.xml
+++ b/JeJu/src/main/webapp/WEB-INF/spring/security-context.xml
@@ -6,7 +6,7 @@
 
 	<security:http pattern="/resources/**" security="none"/>
 
-	<security:http auto-config="true" use-expressions="true">
+	<security:http pattern="/admin/**" auto-config="true" use-expressions="true">
 		<security:csrf disabled="true"/>
         <!-- <security:intercept-url pattern="/admin/login" access="hasRole('ROLE_USER')" /> -->
         <security:form-login
@@ -14,11 +14,13 @@
 	        password-parameter="password"
 	        login-page="/admin/login"
 	        default-target-url="/"
-			login-processing-url="/perform_login" 
+			login-processing-url="/admin/perform_login" 
 			authentication-failure-url="/admin/login?error=true"
 			always-use-default-target="true"
     	/>
+    	<security:logout logout-url="/admin/logout" logout-success-url="/admin/login"/>
     </security:http>
+    
 
     <security:authentication-manager>
         <security:authentication-provider user-service-ref="adminLogin">

--- a/JeJu/src/main/webapp/WEB-INF/views/admin/adminLogin.jsp
+++ b/JeJu/src/main/webapp/WEB-INF/views/admin/adminLogin.jsp
@@ -39,7 +39,7 @@
   <body class="text-center">
     
 <main class="form-signin">
-  <form name="f" action="<c:url value="/perform_login"/>" method="POST">
+  <form name="f" action="<c:url value="/admin/perform_login"/>" method="POST">
     <h1 class="logo fw-normal">TRAVEL JEJU</h1>
     <h2 class="h3 mb-3 fw-normal">Please sign in</h2>
 


### PR DESCRIPTION
1. spring security 로그아웃 url이 기본으로 /logout으로 설정되어 있어서 사용자가 로그아웃을 눌러 /logout로 이동했을 때 관리자 페이지 로그인 (사실 로그아웃 결과)가 나오는 것.
2. 관리자 페이지 로그아웃 url을 지정하여 url 맵핑이 겹치지 않게 만듦

issueNum #63 